### PR TITLE
Fix a bug mentioned in #290

### DIFF
--- a/fec_manager.h
+++ b/fec_manager.h
@@ -195,6 +195,8 @@ struct fec_parameter_t
 		assert(other.rs_cnt>=1);
 		rs_cnt=other.rs_cnt;
 		memcpy(rs_par,other.rs_par,sizeof(rs_parameter_t)*rs_cnt);
+		
+		version++;
 
 		return 0;
 	}

--- a/fec_manager.h
+++ b/fec_manager.h
@@ -190,7 +190,14 @@ struct fec_parameter_t
 		return 0;
 	}
 
+	int clone_fec(fec_parameter_t & other)
+	{
+		assert(other.rs_cnt>=1);
+		rs_cnt=other.rs_cnt;
+		memcpy(rs_par,other.rs_par,sizeof(rs_parameter_t)*rs_cnt);
 
+		return 0;
+	}
 };
 
 extern fec_parameter_t g_fec_par;

--- a/misc.cpp
+++ b/misc.cpp
@@ -292,9 +292,7 @@ int handle_command(char *s)
 			mylog(log_warn,"failed to parse [%s]\n",tmp_str);
 			return -1;
 		}
-		int version=g_fec_par.version;
-		g_fec_par.clone(tmp_par);
-		g_fec_par.version=version;
+		g_fec_par.clone_fec(tmp_par);
 		g_fec_par.version++;
 		strcpy(rs_par_str,tmp_str);
 		//g_fec_data_num=a;

--- a/misc.cpp
+++ b/misc.cpp
@@ -293,7 +293,6 @@ int handle_command(char *s)
 			return -1;
 		}
 		g_fec_par.clone_fec(tmp_par);
-		g_fec_par.version++;
 		strcpy(rs_par_str,tmp_str);
 		//g_fec_data_num=a;
 		//g_fec_redundant_num=b;


### PR DESCRIPTION
2. Only write fec to fifo file will reset all parameters to default value.
I didn't read all the codes of udpspeeder, is this an appropriate way to fix the problem?