### PR TITLE
Fixed off-by-one read which causes a stack overflow. Reported by ASAN.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOURCE_FILES
         tunnel_server.cpp
         my_ev.cpp
 )
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-variable -Wno-unused-parameter -Wno-missing-field-initializers -O2 -g -fsanitize=address,undefined")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-variable -Wno-unused-parameter -Wno-missing-field-initializers -O2 -g -fsanitize=address,undefined -fno-sanitize=shift")
 
 #target_include_directories(speederv2 PRIVATE .)
 #set(CMAKE_LINK_LIBRARY_FLAG "-lrt")

--- a/common.cpp
+++ b/common.cpp
@@ -896,7 +896,7 @@ u32_t djb2(unsigned char *str, int len) {
     u32_t hash = 5381;
     int c;
     int i = 0;
-    while (c = *str++, i++ != len) {
+    while (c = *str++, ++i != len) {
         hash = ((hash << 5) + hash) ^ c; /* (hash * 33) ^ c */
     }
 
@@ -908,7 +908,7 @@ u32_t sdbm(unsigned char *str, int len) {
     u32_t hash = 0;
     int c;
     int i = 0;
-    while (c = *str++, i++ != len) {
+    while (c = *str++, ++i != len) {
         hash = c + (hash << 6) + (hash << 16) - hash;
     }
     // hash=htonl(hash);


### PR DESCRIPTION
```txt
==26656==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffdbc91936c at pc 0x561d962ea0e3 bp 0x7ffdbc918e80 sp 0x7ffdbc918e78 READ of size 1 at 0x7ffdbc91936c thread T0
    #0 0x561d962ea0e2 in sdbm(unsigned char*, int) /home/toni/git/UDPspeeder/common.cpp:911
    #1 0x561d9639b3a5 in std::hash<address_t>::operator()(address_t const&) const /home/toni/git/UDPspeeder/common.h:340
    #2 0x561d9639b3a5 in std::__detail::_Hash_code_base<address_t, std::pair<address_t const, unsigned int>, std::__detail::_Select1st, std::hash<address_t>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, true>::_M_hash_code(address_t const&) const /usr/include/c++/10/bits/hashtable_policy.h:1379
    #3 0x561d9639b3a5 in std::_Hashtable<address_t, std::pair<address_t const, unsigned int>, std::allocator<std::pair<address_t const, unsigned int> >, std::__detail::_Select1st, std::equal_to<address_t>, std::hash<address_t>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::find(address_t const&) /usr/include/c++/10/bits/hashtable.h:1452
    #4 0x561d9639b3a5 in std::unordered_map<address_t, unsigned int, std::hash<address_t>, std::equal_to<address_t>, std::allocator<std::pair<address_t const, unsigned int> > >::find(address_t const&) /usr/include/c++/10/bits/unordered_map.h:920
    #5 0x561d9639b3a5 in conv_manager_t<address_t>::is_data_used(address_t) /home/toni/git/UDPspeeder/connection.h:88
    #6 0x561d9639b3a5 in data_from_local_or_fec_timeout(conn_info_t&, int) /home/toni/git/UDPspeeder/tunnel_client.cpp:68
    #7 0x561d963caa11 in ev_invoke_pending /home/toni/git/UDPspeeder/libev/ev.c:3314
    #8 0x561d963eab2e in ev_run /home/toni/git/UDPspeeder/libev/ev.c:3717
    #9 0x561d9639ee7b in tunnel_client_event_loop() /home/toni/git/UDPspeeder/tunnel_client.cpp:369
    #10 0x561d962e3d03 in main /home/toni/git/UDPspeeder/main.cpp:146
    #11 0x7f37d387cd09 in __libc_start_main ../csu/libc-start.c:308
    #12 0x561d962e4739 in _start (/home/toni/git/UDPspeeder/build/speederv2+0x262739)

Address 0x7ffdbc91936c is located in stack of thread T0 at offset 1052 in frame
    #0 0x561d9639a87f in data_from_local_or_fec_timeout(conn_info_t&, int) /home/toni/git/UDPspeeder/tunnel_client.cpp:3
```