### PR TITLE
makefile: build the cross target with $(CXX) and honour CXXFLAGS/LDFLAGS

### DIFF
--- a/makefile
+++ b/makefile
@@ -51,7 +51,7 @@ cygwin:git_version
 #targes for general cross compile
 
 cross:git_version
-	${cc_cross}   -o ${NAME}_cross    -I. ${SOURCES} ${FLAGS} -lrt -O2
+	${CXX}   -o ${NAME}_cross    -I. ${SOURCES} ${FLAGS} ${CXXFLAGS} ${LDFLAGS} -lrt -O2
 
 cross2:git_version
 	${cc_cross}   -o ${NAME}_cross    -I. ${SOURCES} ${FLAGS} -lrt -static -lgcc_eh -O2
@@ -115,5 +115,6 @@ clean:
 	rm -f ${NAME} ${NAME}_cross ${NAME}.exe ${NAME}_wepoll.exe ${NAME}_mac
 	rm -f git_version.h
 
+gitversion ?= $(shell git rev-parse HEAD 2>/dev/null)
 git_version:
-	    echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > git_version.h
+	    echo "const char *gitversion = \"$(gitversion)\";" > git_version.h


### PR DESCRIPTION
Thanks for UDPspeeder.

The `cross` target hardcodes `cc_cross` to a specific path and doesn't pass `$(CXXFLAGS)`/`$(LDFLAGS)`, so cross-compiling on another machine or through a packaging system (OpenWrt, Buildroot, a distro) means editing the makefile. This builds the `cross` target with the standard `$(CXX)` and appends `$(CXXFLAGS)`/`$(LDFLAGS)`, so the toolchain and its flags can be passed the usual way:

```
make cross CXX=arm-openwrt-linux-g++ CXXFLAGS=... LDFLAGS=...
```

It also makes `gitversion` overridable (`gitversion ?= ...`), so a build from a source tarball with no `.git` can inject the version instead of shelling out to `git`.

This came up while packaging UDPspeeder for OpenWrt (openwrt/packages#30015). It only touches the `cross` target; the native and other targets are unchanged. Thanks for taking a look.
